### PR TITLE
redfin: Enable refresh rate toggle in Settings

### DIFF
--- a/redfin/overlay/packages/apps/Settings/res/values/config.xml
+++ b/redfin/overlay/packages/apps/Settings/res/values/config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2020 The Proton AOSP Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<resources>
+    <!-- Whether to show Smooth Display feature in Settings Options -->
+    <bool name="config_show_smooth_display">true</bool>
+</resources>


### PR DESCRIPTION
Redfin supports switching between 60 and 90 Hz refresh rates, so let's
expose it in Settings -> Display -> Smooth Display for users to save
battery if necessary.

Test: visual confirmation after toggling several times
Change-Id: Ie698ec4d4e738afd2a9055dba2369233103a4f13